### PR TITLE
On Windows and Linux, scroll horizontally when shift is pressed while scrolling

### DIFF
--- a/Quadtastic/Scrollpane.lua
+++ b/Quadtastic/Scrollpane.lua
@@ -21,17 +21,30 @@ local scrollwheel_multiplier = scrollwheel_multipliers[os.os] or 1
 local function handle_input(state, scrollpane_state)
   assert(state.input)
 
+  local scroll_dx = state.input.mouse.wheel_dx
+  local scroll_dy = state.input.mouse.wheel_dy
+
+  -- Scroll horizontally instead of vertically when shift is pressed
+  if (os.win or os.linux) and scroll_dx == 0 then
+    if imgui.is_key_pressed(state, "lshift") or
+       imgui.is_key_pressed(state, "rshift")
+    then
+      scroll_dx = -scroll_dy
+      scroll_dy = 0
+    end
+  end
+
   -- Only handle image panning if the mousewheel was triggered inside
   -- this widget.
   if Scrollpane.is_mouse_inside_widget(state, scrollpane_state) then
       local threshold = 3
-    if state.input.mouse.wheel_dx ~= 0 then
-      scrollpane_state.tx = scrollpane_state.x + scrollwheel_multiplier*state.input.mouse.wheel_dx
+    if scroll_dx ~= 0 then
+      scrollpane_state.tx = scrollpane_state.x + scrollwheel_multiplier*scroll_dx
     elseif math.abs(scrollpane_state.last_dx) > threshold then
       scrollpane_state.tx = scrollpane_state.x + scrollpane_state.last_dx
     end
-    if state.input.mouse.wheel_dy ~= 0 then
-      scrollpane_state.ty = scrollpane_state.y - scrollwheel_multiplier*state.input.mouse.wheel_dy
+    if scroll_dy ~= 0 then
+      scrollpane_state.ty = scrollpane_state.y - scrollwheel_multiplier*scroll_dy
     elseif math.abs(scrollpane_state.last_dy) > threshold then
       scrollpane_state.ty = scrollpane_state.y + scrollpane_state.last_dy
     end

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 ### Unreleased
 
  - Fix slow scrolling on Linux and Windows
+ - On Windows and Linux, scroll horizontally when shift is pressed
 
 ### Release 0.5.3, 2017-05-02
 


### PR DESCRIPTION
When shift is pressed, the viewport of a scroll pane will be moved horizontally instead of vertically.
This makes it easier to scroll horizontally without a trackpad.

This already works natively on macOS. Now it also works on Windows and Linux.

Resolves #10 