### PR TITLE
Reset scroll position when switching directories in file browser

### DIFF
--- a/Quadtastic/Dialog.lua
+++ b/Quadtastic/Dialog.lua
@@ -236,6 +236,9 @@ local function switch_to(data, new_basepath)
   -- Clear chosen file
   data.chosen_file = nil
 
+  -- Clear scrollpane state to reset the scroll position to the top
+  data.scrollpane_state = nil
+
   local success, err = lfs.chdir(new_basepath)
   if success then
     data.basepath = lfs.currentdir()


### PR DESCRIPTION
Previously, when choosing a file to open or save, the file list would not reset to the beginning when switching directories. This PR fixes that by resetting the state of the scrollpane whenever directories are changed.

Resolves #13 
