### PR TITLE
When displaying files, always display them in alphabetical order

### DIFF
--- a/Quadtastic/Dialog.lua
+++ b/Quadtastic/Dialog.lua
@@ -234,8 +234,22 @@ end
 
 local function switch_to(data, new_basepath)
   local function create_filelist()
-    local filelist = {}
+
+    -- First accumulate all file names into a table
+    local filenames = {}
     for file in lfs.dir(".") do
+      table.insert(filenames, file)
+    end
+
+    -- Then sort the file names so that the files are displayed in alphabetical
+    -- order no matter how they are returned by the file system.
+    -- A custom comparator is used to sort the file names case-insensitive.
+    table.sort(filenames,
+               function(a, b) return string.lower(a) < string.lower(b) end)
+
+    -- Then store file name and type into a new table
+    local filelist = {}
+    for _, file in ipairs(filenames) do
       local mode = lfs.attributes(file, "mode")
       table.insert(filelist, {name=file, type=mode})
     end

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,8 @@
 
 ### Unreleased
 
-There are currently no unreleased changes
+ - Fix an issue where files would be listed out of alphabetic order on some
+   file systems
 
 ### Release 0.6.2, 2017-08-23
 


### PR DESCRIPTION
So far, the order in which files were displayed in the file dialogs depended on
the order in which they were enumerated by the file system. This commit
explicitly sorts the filenames alphabetically and case-insensitive, so that the
order in which they are displayed is not dependend on the used file system.

Resolves #24 