### PR TITLE
Add custom exporter directory to dirs searched by 'Reload exporters'

### DIFF
--- a/Quadtastic/QuadtasticLogic.lua
+++ b/Quadtastic/QuadtasticLogic.lua
@@ -1055,7 +1055,8 @@ function QuadtasticLogic.transitions(interface) return {
   end,
 
   reload_exporters = function(app, data, callback)
-    local success, more, count = pcall(exporters.list, {S.exporters_dirname})
+    local success, more, count = pcall(exporters.list, {S.exporters_dirname,
+                                                        S.custom_exporters_dirname})
     if success then
       data.exporters = more
       -- Update previous exporter


### PR DESCRIPTION
'Reload exporters' only scanend the directory containing the built-in
exporters, and not the one that contains custom exporters.

Resolves #38